### PR TITLE
Fixed test failure by comparing maps instead of json strings

### DIFF
--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.plugin;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Envelope;
@@ -9,12 +10,18 @@ import io.cucumber.messages.types.Timestamp;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MessageFormatterTest {
 
@@ -32,9 +39,21 @@ public class MessageFormatterTest {
         bus.send(Envelope.of(testRunFinished));
 
         String ndjson = new String(bytes.toByteArray(), UTF_8);
-        assertThat(ndjson, containsString("" +
-                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}\n" +
-                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}\n"));
+        String expectedJson = "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}},\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            Map<String, Object> expectedMap = objectMapper.readValue(expectedJson, Map.class);
+
+            String[] ndjsonObjects = ndjson.split("\\n");
+            Map<String, Object> ndjsonMap = new HashMap<>();
+            for (String ndjsonObject : ndjsonObjects) {
+                ndjsonMap.putAll(objectMapper.readValue(ndjsonObject, Map.class));
+            }
+
+            assertThat(expectedMap.entrySet(), everyItem(is(in(ndjsonMap.entrySet()))));
+        } catch (IOException e) {
+            fail("An exception occurred while processing JSON: " + e.getMessage());
+        }
     }
 
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
@@ -1,32 +1,26 @@
 package io.cucumber.core.plugin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Envelope;
 import io.cucumber.messages.types.TestRunFinished;
 import io.cucumber.messages.types.TestRunStarted;
 import io.cucumber.messages.types.Timestamp;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.time.Clock;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class MessageFormatterTest {
 
     @Test
-    void test() {
+    void test() throws JSONException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         MessageFormatter formatter = new MessageFormatter(bytes);
         EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
@@ -39,20 +33,13 @@ public class MessageFormatterTest {
         bus.send(Envelope.of(testRunFinished));
 
         String ndjson = new String(bytes.toByteArray(), UTF_8);
-        String expectedJson = "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}},\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}";
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            Map<String, Object> expectedMap = objectMapper.readValue(expectedJson, Map.class);
-
-            String[] ndjsonObjects = ndjson.split("\\n");
-            Map<String, Object> ndjsonMap = new HashMap<>();
-            for (String ndjsonObject : ndjsonObjects) {
-                ndjsonMap.putAll(objectMapper.readValue(ndjsonObject, Map.class));
-            }
-
-            assertThat(expectedMap.entrySet(), everyItem(is(in(ndjsonMap.entrySet()))));
-        } catch (IOException e) {
-            fail("An exception occurred while processing JSON: " + e.getMessage());
+        String[] ndjsonArray = ndjson.split("\\n");
+        String[] expectedArray = {
+                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}",
+                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}"
+        };
+        for (int i = 0; i < ndjsonArray.length; i++) {
+            JSONAssert.assertEquals(expectedArray[i], ndjsonArray[i], JSONCompareMode.LENIENT);
         }
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
@@ -8,14 +8,16 @@ import io.cucumber.messages.types.TestRunStarted;
 import io.cucumber.messages.types.Timestamp;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayOutputStream;
 import java.time.Clock;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT;
 
 public class MessageFormatterTest {
 
@@ -33,13 +35,14 @@ public class MessageFormatterTest {
         bus.send(Envelope.of(testRunFinished));
 
         String ndjson = new String(bytes.toByteArray(), UTF_8);
-        String[] ndjsonArray = ndjson.split("\\n");
-        String[] expectedArray = {
+        String[] actual = ndjson.split("\\n");
+        String[] expected = {
                 "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}",
                 "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}"
         };
-        for (int i = 0; i < ndjsonArray.length; i++) {
-            JSONAssert.assertEquals(expectedArray[i], ndjsonArray[i], JSONCompareMode.LENIENT);
+        assertThat(actual.length, equalTo(expected.length));
+        for (int i = 0; i < actual.length; i++) {
+            assertEquals(expected[i], actual[i], STRICT);
         }
     }
 


### PR DESCRIPTION
Created this PR to fix 1 flaky test - [test](https://github.com/cucumber/cucumber-jvm/blob/main/cucumber-core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java#L22)
----------------
1. **How were these test identified as flaky?**
This test was identified as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. **What was the error?**
When the test convert bytes to json string `String ndjson = new String(bytes.toByteArray(), UTF_8);`, the order of keys (i.e. seconds, nano, testRunStarted, testRunFinished, etc) is not guaranteed. Thus, when we compare this String variable 'ndjson' directly to hardcoded string `"{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}\n{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}\n"`, it may fail sometimes because the order could be different than the expected order.
```
[ERROR] Failures: 
[ERROR]   MessageFormatterTest.test:35 
Expected: a string containing "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}\n{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}\n"
     but: was "{"testRunStarted":{"timestamp":{"nanos":0,"seconds":10}}}
{"testRunFinished":{"timestamp":{"nanos":0,"seconds":15},"success":true}}
"
```
3. **What is the fix?**
```
assertThat(expectedMap.entrySet(), everyItem(is(in(ndjsonMap.entrySet()))));
```
Instead of comparing json strings, we can convert json to Map and then compare the maps. This PR proposes to compare Maps instead of json strings in test. In the above code snippet, the assertion checks that every entry in expectedMap is present in ndjsonMap. If this assertion passes for every entry in expectedMap, it means that the key-value pairs in expectedMap are all present in ndjsonMap.

--------------
You can run the following commands to run the test using NonDex tool:
```
mvn -pl cucumber-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.cucumber.core.plugin.MessageFormatterTest#test
```

Test Environment:
```
java version 11.0.19
Apache Maven 3.9.5
```
Kindly let me know if this fix is acceptable.
Thank you
